### PR TITLE
Add text.md markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Atom support Weave.jl and Pweave
 
 Atom syntax highlighting for [Weave.jl](http://weavejl.mpastell.com) and

--- a/grammars/pweave_md.cson
+++ b/grammars/pweave_md.cson
@@ -9,7 +9,6 @@ patterns: [
       'include' : 'source.pweave.noweb'
     }
     {
-    #'begin': '^([`~]{3,})(\\{|\\{\\.|)(julia)(;|)\\s*(.*?)(\\}|)\\s*$'
     'begin': '^([`~]{3,})(\\{|\\{\\.|)(python)(,|)\\s*(.*?)(\\}|)\\s*$'
     'beginCaptures':
       '1':
@@ -36,6 +35,9 @@ patterns: [
     }
     {
       'include': 'source.gfm'
+    }
+    {
+      'include': 'text.md'
     }
 
   ]

--- a/grammars/weave_md.cson
+++ b/grammars/weave_md.cson
@@ -37,4 +37,7 @@ patterns: [
     {
       'include': 'source.gfm'
     }
+    {
+      'include': 'text.md'
+    }
 ]


### PR DESCRIPTION
I have added the scope for language-markdown by @burodepeper (`text.md`) -- when this package is installed, it deactivates the default language-gfm, and so this package is not highlighting the markdown files correctly anymore.