### PR TITLE
Add python syntax highlighting to inline code chunks

### DIFF
--- a/grammars/pweave_md.cson
+++ b/grammars/pweave_md.cson
@@ -34,6 +34,22 @@ patterns: [
     ]
     }
     {
+      'begin': '\\<\\%=?'
+      'beginCaptures':
+        '0':
+          'name': 'markup.bold.weave.md'
+      'end': '\\%\\>'
+      'endCaptures':
+        '0':
+          'name': 'markup.bold.weave.md'
+      'contentName': 'source.embedded.python'
+      'patterns': [
+        {
+          'include': 'source.python'
+        }
+      ]
+    }
+    {
       'include': 'source.gfm'
     }
     {


### PR DESCRIPTION
This is a small addition to the pweave markdown file so that inline code chunks (using `<% python code %>` or `<%= python code %>`) are colored as Python code. Because Hydrogen uses highlighting scopes to determine what is python code, this also allows for Hydrogen to now run code inside inline chunks the same was as it can with fenced code blocks:

![image](https://user-images.githubusercontent.com/15164633/37608455-f75012fc-2b70-11e8-933b-b1fd0e973207.png)
