### PR TITLE
Add default keymaps that bind to language-markdown package

### DIFF
--- a/keymaps/language-weave.cson
+++ b/keymaps/language-weave.cson
@@ -1,4 +1,34 @@
+'.platform-darwin atom-text-editor[data-grammar="source weave md"]':
+  'cmd-shift-x': 'markdown:toggle-task'
+'.platform-win32 atom-text-editor[data-grammar="source weave md"]':
+  'ctrl-shift-x': 'markdown:toggle-task'
+'.platform-linux atom-text-editor[data-grammar="source weave md"]':
+  'ctrl-shift-x': 'markdown:toggle-task'
 
+'atom-text-editor[data-grammar="source weave md"]':
+  'tab': 'markdown:indent-list-item'
+  'shift-tab': 'markdown:outdent-list-item'
+  '_': 'markdown:emphasis'
+  '*': 'markdown:strong-emphasis'
+  '~': 'markdown:strike-through'
+  '@': 'markdown:link'
+  '!': 'markdown:image'
+
+'.platform-darwin atom-text-editor[data-grammar="source pweave md"]':
+  'cmd-shift-x': 'markdown:toggle-task'
+'.platform-win32 atom-text-editor[data-grammar="source pweave md"]':
+  'ctrl-shift-x': 'markdown:toggle-task'
+'.platform-linux atom-text-editor[data-grammar="source pweave md"]':
+  'ctrl-shift-x': 'markdown:toggle-task'
+
+'atom-text-editor[data-grammar="source pweave md"]':
+  'tab': 'markdown:indent-list-item'
+  'shift-tab': 'markdown:outdent-list-item'
+  '_': 'markdown:emphasis'
+  '*': 'markdown:strong-emphasis'
+  '~': 'markdown:strike-through'
+  '@': 'markdown:link'
+  '!': 'markdown:image'
 
 '.platform-linux .item-views > atom-text-editor[data-grammar="source weave md"],
 .platform-linux .item-views > atom-text-editor[data-grammar="source weave latex"],


### PR DESCRIPTION
This addition makes it so that if the user has the popular [language-markdown](https://github.com/burodepeper/language-markdown) package installed, the standard commands in that package will work when editing a `.pmd` file. So if I have a `.pmd` file open, I can highlight a word and press `@`, and it will make a link for me. 

If a user doesn't have language-markdown installed, I'm pretty sure that the literal `@` will be pasted as expected.