### PR TITLE
Add commands to weave files and preview them in Atom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.log
+node_modules

--- a/lib/html-preview.js
+++ b/lib/html-preview.js
@@ -1,0 +1,79 @@
+'use babel'
+
+import {$, ScrollView} from 'atom-space-pen-views'
+import { CompositeDisposable } from 'atom'
+import fs from 'fs-plus'
+
+export default class HTMLPreview extends ScrollView {
+    static content () {
+        return this.div({class: 'html-view', tabindex: -1}, () => {
+            this.div({outlet: 'container', style: 'width:100%;height:100%;background-color:white'})
+        })
+    }
+
+    constructor (uri) {
+        super()
+        this.uri = uri
+        this.filePath = uri.split('://')[1]
+
+        this.showDocument()
+        this.watcher = this.keepUpdated()
+    }
+
+    showDocument () {
+        this.webview = document.createElement('webview')
+        this.webview.setAttribute('src', this.filePath)
+        this.webview.setAttribute('style', 'width: 100%; height: 100%')
+        this.container[0].appendChild(this.webview)
+    }
+
+    keepUpdated () {
+        if (fs.existsSync(this.filePath)) {
+            let watcher = fs.watch(this.filePath, {}, (eventType, filename) => {
+                if (eventType === 'change') {
+                    this.reloadWebview()
+                } else {
+                    watcher.close()
+                }
+            })
+            return watcher
+        }
+    }
+
+    reloadWebview () {
+        if (this.webview) {
+            this.webview.reloadIgnoringCache()
+        }
+    }
+
+    serialize () {
+        return {
+            uri: this.uri,
+            filePath: this.filePath,
+            deserializer: 'HTMLPreviewDeserializer'
+        }
+    }
+
+    getTitle() {
+        if (this.filePath) {
+            return 'Preview: ' + path.basename(this.filePath)
+        } else {
+            return 'untitled'
+        }
+    }
+
+    getURI() {
+        return this.uri
+    }
+
+    getPath() {
+        return this.filePath
+    }
+
+    destroy() {
+        if (this.watcher) {
+            this.watcher.close()
+        }
+        return this.detach()
+    }
+}

--- a/lib/html-preview.js
+++ b/lib/html-preview.js
@@ -15,6 +15,11 @@ export default class HTMLPreview extends ScrollView {
         super()
         this.uri = uri
         this.filePath = uri.split('://')[1]
+        if (process.platform === 'win32') {
+            this.filePath = this.filePath.replace(/\\/g, "/")
+        }
+        this.isAttached = false
+        this.id = Math.round(Math.random()*10**10)
 
         this.showDocument()
         this.watcher = this.keepUpdated()
@@ -22,9 +27,11 @@ export default class HTMLPreview extends ScrollView {
 
     showDocument () {
         this.webview = document.createElement('webview')
+        this.webview.id = this.id
         this.webview.setAttribute('src', this.filePath)
         this.webview.setAttribute('style', 'width: 100%; height: 100%')
         this.container[0].appendChild(this.webview)
+        this.isAttached = true
     }
 
     keepUpdated () {
@@ -41,7 +48,7 @@ export default class HTMLPreview extends ScrollView {
     }
 
     reloadWebview () {
-        if (this.webview) {
+        if (this.webview && this.isAttached && document.getElementById(`${this.id}`)) {
             this.webview.reloadIgnoringCache()
         }
     }

--- a/lib/html-preview.js
+++ b/lib/html-preview.js
@@ -15,9 +15,6 @@ export default class HTMLPreview extends ScrollView {
         super()
         this.uri = uri
         this.filePath = uri.split('://')[1]
-        if (process.platform === 'win32') {
-            this.filePath = this.filePath.replace(/\\/g, "/")
-        }
         this.isAttached = false
         this.id = Math.round(Math.random()*10**10)
 

--- a/lib/html-preview.js
+++ b/lib/html-preview.js
@@ -3,6 +3,7 @@
 import {$, ScrollView} from 'atom-space-pen-views'
 import { CompositeDisposable } from 'atom'
 import fs from 'fs-plus'
+import path from 'path'
 
 export default class HTMLPreview extends ScrollView {
     static content () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -50,13 +50,6 @@ function weave(format) {
         return
     }
 
-    if (format === 'pdf' && !atom.packages.isPackageActive('pdf-view')) {
-        atom.notifications.addError("Can't display PDF", {
-            description: 'Please install the [pdf-view](https://github.com/izuzak/atom-pdf-view) package.'
-        })
-        return
-    }
-
     juliaClient.boot()
 
     ed = atom.workspace.getActiveTextEditor()
@@ -87,6 +80,15 @@ function weave(format) {
 
     evalsimple = juliaClient.import({rpc: ['evalsimple']}).evalsimple
     evalsimple(weaveCommand).then((res) => {
+        if (!atom.config.get('language-weave.showPreview')) return
+
+        if (format === 'pdf' && !atom.packages.isPackageActive('pdf-view')) {
+            atom.notifications.addError("Can't display PDF", {
+                description: 'Please install the [pdf-view](https://github.com/izuzak/atom-pdf-view) package.'
+            })
+            return
+        }
+
         if (res == 1) {
             if (format == 'html') {
                 outpath = 'preview://' + outpath
@@ -126,6 +128,14 @@ export function consumeToolBar (getToolBar) {
         tooltip: 'Weave PDF'
     })
     toolbar.addSpacer()
+}
+
+export var config = {
+    showPreview: {
+        type: 'boolean',
+        default: true,
+        title: 'Show Previews'
+    }
 }
 
 export function deactivate () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -67,6 +67,9 @@ function weave(format) {
         })
         return
     }
+    if (process.platform === 'win32') {
+        edpath = edpath.replace(/\\/g, "/")
+    }
     outpath = edpath.split('.')
     outpath.pop()
     outpath = outpath.join('.') + '.' + format

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,7 +45,14 @@ export function activate () {
 function weave(format) {
     if (juliaClient === null) {
         atom.notifications.addError("Juno not installed", {
-            description: "Juno needs to be installed to weave files."
+            description: "[Juno](http://junolab.org/) needs to be installed to weave files."
+        })
+        return
+    }
+
+    if (format === 'pdf' && atom.packages.isPackageActive('pdf-view')) {
+        atom.notifications.addError("Can't display PDF", {
+            description: 'Please install the [pdf-view](https://github.com/izuzak/atom-pdf-view) package.'
         })
         return
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,11 @@
 'use babel'
 import { CompositeDisposable } from 'atom'
+import path from 'path'
 
-var subs
+let subs = null
+let toolbar = null
+let juliaClient = null
+let HTMLPreviewView = require('./html-preview.js')
 
 export function activate () {
     subs = new CompositeDisposable()
@@ -24,8 +28,109 @@ export function activate () {
             }
         }))
     }
+
+    subs.add(atom.workspace.addOpener((uri) => {
+        console.log(uri);
+        if (path.extname(uri) === '.html' && uri.startsWith('preview://')) {
+            return new HTMLPreviewView(uri)
+        }
+    }))
+
+    subs.add(atom.commands.add('atom-text-editor',
+        'weave:weave-to-pdf', () => weave('pdf')))
+    subs.add(atom.commands.add('atom-text-editor',
+        'weave:weave-to-html', () => weave('html')))
+}
+
+function weave(format) {
+    if (juliaClient === null) {
+        atom.notifications.addError("Juno not installed", {
+            description: "Juno needs to be installed to weave files."
+        })
+        return
+    }
+
+    juliaClient.boot()
+
+    ed = atom.workspace.getActiveTextEditor()
+    pane = atom.workspace.getActivePane()
+    if (!ed) {
+        atom.notifications.addError("No editor selected", {
+            description: "Select an editor to weave a file."
+        })
+        return
+    }
+    edpath = ed.getPath()
+    if (!edpath) {
+        atom.notifications.addError("File is not saved", {
+            description: "Please save your file to weave it."
+        })
+        return
+    }
+    outpath = edpath.split('.')
+    outpath.pop()
+    outpath = outpath.join('.') + '.' + format
+
+    weaveCommand  = 'using Weave;'
+    weaveCommand += 'try;'
+    weaveCommand += `weave("${edpath}", doctype="md2${format}"); 1;`
+    weaveCommand += 'catch err;'
+    weaveCommand += '@error("Weaving failed.", error=err); 0;'
+    weaveCommand += 'end'
+
+    evalsimple = juliaClient.import({rpc: ['evalsimple']}).evalsimple
+    evalsimple(weaveCommand).then((res) => {
+        if (res == 1) {
+            if (format == 'html') {
+                outpath = 'preview://' + outpath
+            }
+            atom.workspace.open(outpath, {
+                searchAllPanes: true,
+                split: 'right'
+            }).then(() => {
+                pane.activate()
+                pane.activateItem(ed)
+            })
+        } else {
+            atom.notifications.addError("Weaving file failed", {
+                description: "See the REPL for details."
+            })
+        }
+    })
+}
+
+export function consumeJuliaClient (client) {
+    juliaClient = client
+}
+
+export function consumeToolBar (getToolBar) {
+    toolbar = getToolBar()
+    toolbar.addSpacer()
+    toolbar.addButton({
+        icon: 'social-html5',
+        iconset: 'ion',
+        callback: 'weave:weave-to-html',
+        tooltip: 'Weave HTML'
+    })
+    toolbar.addButton({
+        icon: 'file-pdf',
+        iconset: 'fa',
+        callback: 'weave:weave-to-pdf',
+        tooltip: 'Weave PDF'
+    })
+    toolbar.addSpacer()
 }
 
 export function deactivate () {
+    if (toolbar) {
+        toolbar.removeItems()
+        toolbar = null
+    }
     subs.dispose()
+}
+
+export function deserialize({filePath, uri}) {
+    if (require('fs-plus').isFileSync(filePath)) {
+        return new HTMLPreviewView(uri)
+    }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -50,7 +50,7 @@ function weave(format) {
         return
     }
 
-    if (format === 'pdf' && atom.packages.isPackageActive('pdf-view')) {
+    if (format === 'pdf' && !atom.packages.isPackageActive('pdf-view')) {
         atom.notifications.addError("Can't display PDF", {
             description: 'Please install the [pdf-view](https://github.com/izuzak/atom-pdf-view) package.'
         })

--- a/package.json
+++ b/package.json
@@ -20,5 +20,24 @@
       "package.json"
     ]
   },
+  "dependencies": {
+    "fs-plus": "2.x",
+    "atom-space-pen-views": "^2.0.3"
+  },
+  "deserializers": {
+    "HTMLPreviewDeserializer": "deserialize"
+  },
+  "consumedServices": {
+    "julia-client": {
+      "versions": {
+        "0.1.0": "consumeJuliaClient"
+      }
+    },
+    "tool-bar": {
+      "versions": {
+        "^0 || ^1": "consumeToolBar"
+      }
+    }
+  },
   "folders": []
 }


### PR DESCRIPTION
If Juno (and Weave.jl) s installed you can now `weave` arbitrary files and preview them in Atom.

This implements a HTML preview pane and makes use of https://github.com/izuzak/atom-pdf-view for previewing PDFs.

![image](https://user-images.githubusercontent.com/6735977/53697281-55979480-3dd0-11e9-805e-4b215565bbfa.png)

The previews auto-reload when the `*.html`/`*.pdf` changes.

Possible improvements:
1. Allow setting a different path for generating output.
2. Or, more generally, allow specifying arbitrary kwargs for `weave`.

Not sure how much either of those are used in practice.